### PR TITLE
Switches from implicit all-rights-reserved to Apache-2.0.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,13 @@
+Copyright 2013, Bigcommerce Pty Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "bigcommerce/statsd-client",
+    "license": "Apache-2.0",
     "require-dev": {
         "phpunit/phpunit": "3.7"
     },


### PR DESCRIPTION
See:
- https://intranet.bigcommerce.com/display/DEVREF/RFC+-+Open+Source+Release:+StatsD+Client
- https://jira.bigcommerce.com/browse/OPEN-10

(This PR description can be edited to remove references to the above, if desired.)
