### PR TITLE
Adds badges for external services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 StatsD Client
 =============
 
+[![Build Status](https://travis-ci.org/bigcommerce/statsd-client.png?branch=master)](https://travis-ci.org/bigcommerce/statsd-client)
+
 A very simple StatsD client for PHP. Records timing, increment, and count metrics.
 
 Install
@@ -8,7 +10,7 @@ Install
 
 Require `bigcommerce/statsd-client` as a dependency in your `composer.json` manifest:
 
-```
+```php
 require: {
 	"bigcommerce/statsd-client": "1.0"
 }
@@ -17,5 +19,5 @@ require: {
 Authors
 -------
 
-- @chaitanyakuber
-- @gwilym
+- [@chaitanyakuber](https://github.com/chaitanyakuber)
+- [@gwilym](https://github.com/gwilym)


### PR DESCRIPTION
:information_desk_person: This change adds a badge for the Travis CI build status, as well as updating the author links.