### PR TITLE
porting 'reuse sockets' code from bc app to this lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "bigcommerce/statsd-client",
     "license": "Apache-2.0",
     "require-dev": {
-        "phpunit/phpunit": "3.7"
+        "phpunit/phpunit": "~4.0"
     },
     "autoload": {
         "psr-0": {

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -30,7 +30,7 @@ class ClientTest extends PHPUnit_Framework_TestCase
 		$this->assertTrue($statsd->increment($data, 100));
 	}
 
-	public function testIncrementWitMockedUpdateStats()
+	public function testIncrementWithMockedUpdateStats()
 	{
 		$statsd = $this->getEnabledMockStatsObject(array('updateStats'));
 		$statsd->expects($this->exactly(1))
@@ -41,7 +41,7 @@ class ClientTest extends PHPUnit_Framework_TestCase
 		$this->assertTrue($statsd->increment($data, 0.5));
 	}
 
-	public function testIncrementWitMockedSocketSend()
+	public function testIncrementWithMockedSocketSend()
 	{
 		$data = array('api.products');
 		$dataSent = 'api.products:1|c';

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -64,6 +64,18 @@ class ClientTest extends PHPUnit_Framework_TestCase
 		$this->assertTrue($statsd->decrement($data));
 	}
 
+	public function testIncrementWithReuseSocket()
+	{
+		$statsd = $this->getEnabledMockStatsObject(array('_writeDataToSocket'));
+		$statsd->setReuseSocket(true);
+		$statsd->expects($this->exactly(2))
+			   ->method('_writeDataToSocket')
+			   ->with($this->anything(), $this->anything());
+		$data = array('api.products');
+		$this->assertTrue($statsd->increment($data));
+		$this->assertTrue($statsd->increment($data));
+	}
+
 	public function testDecrementWithString()
 	{
 		$statsd = $this->getEnabledMockStatsObject(array('_writeDataToSocket'));

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -64,16 +64,48 @@ class ClientTest extends PHPUnit_Framework_TestCase
 		$this->assertTrue($statsd->decrement($data));
 	}
 
-	public function testIncrementWithReuseSocket()
+	public function testSameSocketAfterSuccessfulIncrement()
 	{
 		$statsd = $this->getEnabledMockStatsObject(array('_writeDataToSocket'));
-		$statsd->setReuseSocket(true);
-		$statsd->expects($this->exactly(2))
+		$statsd->expects($this->any())
 			   ->method('_writeDataToSocket')
-			   ->with($this->anything(), $this->anything());
-		$data = array('api.products');
-		$this->assertTrue($statsd->increment($data));
-		$this->assertTrue($statsd->increment($data));
+			   ->will($this->returnValue(true));
+
+		$statsd->setReuseSocket(true);
+
+		$class = new ReflectionClass('StatsD\\Client');
+		$getSocket = $class->getMethod('getSocket');
+		$getSocket->setAccessible(true);
+
+		$statsd->increment('foo');
+		$socketA = $getSocket->invokeArgs($statsd, array());
+
+		$statsd->increment('bar');
+		$socketB = $getSocket->invokeArgs($statsd, array());
+
+		$this->assertSame($socketA, $socketB);
+	}
+
+	public function testSocketChangedAfterUnsuccessfulIncrement()
+	{
+		$statsd = $this->getEnabledMockStatsObject(array('_writeDataToSocket'));
+		$statsd->expects($this->any())
+			   ->method('_writeDataToSocket')
+			   ->will($this->returnValue(false));
+
+		$statsd->setReuseSocket(true);
+
+		$class = new ReflectionClass('StatsD\\Client');
+		$getSocket = $class->getMethod('getSocket');
+		$getSocket->setAccessible(true);
+
+		$statsd->increment('foo');
+		$socketA = $getSocket->invokeArgs($statsd, array());
+
+		$statsd->increment('bar');
+		$socketB = $getSocket->invokeArgs($statsd, array());
+
+		$this->assertNotSame($socketA, $socketB);
 	}
 
 	public function testDecrementWithString()


### PR DESCRIPTION
see https://github.com/bigcommerce/bigcommerce/commit/5773817ab9af0d56db4e79892e018a219c1fc49c (circa early 2014)

note the original changeset had no tests, this is a port of that changeset to alleviate some performance issues with regards to data daily crons

high usage of this statsd lib causes a lot of dns lookups due to fsockopen/close cycles, and this has been exacerbated in production by the recent changes to dns infrastructure

@subramanyamchitti @bc-davidb cc @bigcommerce/data

can't get the test suite running locally, opening pr to get travis running it